### PR TITLE
fix memory leak at JNI layer, and trigger partition cleanup by Spark

### DIFF
--- a/caffe-distri/src/main/cpp/jni/JniFloatBlob.cpp
+++ b/caffe-distri/src/main/cpp/jni/JniFloatBlob.cpp
@@ -194,7 +194,7 @@ JNIEXPORT jlong JNICALL Java_com_yahoo_ml_jcaffe_FloatBlob_set_1gpu_1data(JNIEnv
         //set new data
         data = new_data;
     }
-    native_ptr->set_cpu_data(data);
+    native_ptr->set_gpu_data(data);
 
     if(dataaddress)
         delete (jbyte*) dataaddress;

--- a/caffe-distri/src/main/cpp/jni/JniMat.cpp
+++ b/caffe-distri/src/main/cpp/jni/JniMat.cpp
@@ -56,7 +56,7 @@ JNIEXPORT void JNICALL Java_com_yahoo_ml_jcaffe_Mat_deallocate
 
     //Mat object is only one responsible for cleaning itself and it's data 
     if(dataaddress){
-        delete (jbyte*)dataaddress;
+        delete[] (jbyte*)dataaddress;
     }
     delete (cv::Mat*) native_ptr;
 }


### PR DESCRIPTION
   * delet[] for Mat byte array
   * consume all examples in a partition