### PR TITLE
add RDMA sync for ctrl signal

### DIFF
--- a/caffe-distri/include/util/rdma_sync.hpp
+++ b/caffe-distri/include/util/rdma_sync.hpp
@@ -12,6 +12,8 @@
 #include "caffe/solver.hpp"
 #include "util/rdma.hpp"
 
+#define CTRL_BUF_SIZE 1
+
 namespace caffe {
 
 /**
@@ -48,7 +50,7 @@ class RDMASync : public P2PSync<Dtype> {
   RDMASync(shared_ptr<Solver<Dtype> > solver,
            const vector<shared_ptr<RDMAChannel> >& peers, int rank);
   virtual ~RDMASync();
-  void sync();
+  void sync(bool data=true);
 
  protected:
   void chunk(int peer, size_t* offs, size_t* size);
@@ -70,6 +72,9 @@ class RDMASync : public P2PSync<Dtype> {
   vector<shared_ptr<RDMABuffer> > data_recv_;
   vector<shared_ptr<RDMABuffer> > diff_send_;
   vector<shared_ptr<RDMABuffer> > diff_recv_;
+  // RDMA control signal for sync purpose
+  vector<shared_ptr<RDMABuffer> > ctrl_send_;
+  vector<shared_ptr<RDMABuffer> > ctrl_recv_;
 
   // Weights and gradients buffers and size
   using Params<Dtype>::size_;

--- a/caffe-distri/src/main/cpp/CaffeNet.cpp
+++ b/caffe-distri/src/main/cpp/CaffeNet.cpp
@@ -487,7 +487,7 @@ bool SocketCaffeNet<Dtype>::connect(vector<const char*>& peer_addresses) {
 template<typename Dtype>
 void RDMACaffeNet<Dtype>::sync()  {
     if (this->cluster_size_ > 1)
-        boost::static_pointer_cast<RDMASync<Dtype> >(this->syncs_[0])->sync();
+        boost::static_pointer_cast<RDMASync<Dtype> >(this->syncs_[0])->sync(false);
 }
 #endif
 


### PR DESCRIPTION
CaffeProcessor.Sync() is used to synchronize the executors, acting as a barrier. 
Previously, we re-use RDMASync::sync() for this purpose. But due to interleaving of training and validation operations, the driver thread and solver thread could call sync() at the same time. We separate this two scenarios with a new RDMASync::sync(bool) function.