### PR TITLE
add one extra recv request for ctrl signals

### DIFF
--- a/caffe-distri/src/main/cpp/util/rdma.cpp
+++ b/caffe-distri/src/main/cpp/util/rdma.cpp
@@ -168,7 +168,9 @@ RDMAChannel::RDMAChannel(const RDMAAdapter& adapter)
     RecvMR(i);
   }
 
-  // Create initial recv request
+  // Create initial recv request for data. 
+  recv();
+  // Create initial recv request for ctrl signals.
   recv();
 }
 


### PR DESCRIPTION
Need two initial recv requests since there are potentially two parallel RDMA-Writes, one for data and another one for control signals.