### PR TITLE
Enable Apache Spark 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,28 @@ LD_LIBRARY_PATH2=${LD_LIBRARY_PATH}:${CAFFE_ON_SPARK}/caffe-public/distribute/li
 DYLD_LIBRARY_PATH ?=/home/y/lib64:/home/y/lib64/mkl/intel64
 DYLD_LIBRARY_PATH2=${DYLD_LIBRARY_PATH}:${CAFFE_ON_SPARK}/caffe-public/distribute/lib:${CAFFE_ON_SPARK}/caffe-distri/distribute/lib:/usr/lib64:/lib64 
 
-build: 
+export SPARK_VERSION=$(shell ${SPARK_HOME}/bin/spark-submit --version 2>&1 | grep version | awk '{print $$5}' | cut -d'.' -f1)
+ifeq (${SPARK_VERSION}, 2)
+    export MVN_SPARK_FLAG=-Dspark2
+endif
+
+build:
 	cd caffe-public; make proto; make -j4 -e distribute; cd ..
-	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; mvn -B package -DskipTests
+	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; mvn ${MVN_SPARK_FLAG} -B package -DskipTests
 	jar -xvf caffe-grid/target/caffe-grid-0.1-SNAPSHOT-jar-with-dependencies.jar META-INF/native/linux64/liblmdbjni.so
 	mv META-INF/native/linux64/liblmdbjni.so ${CAFFE_ON_SPARK}/caffe-distri/distribute/lib
 	${CAFFE_ON_SPARK}/scripts/setup-mnist.sh
-	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; mvn -B package
+	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; mvn ${MVN_SPARK_FLAG} -B package
 	cp -r ${CAFFE_ON_SPARK}/caffe-public/python/caffe ${CAFFE_ON_SPARK}/caffe-grid/src/main/python/
 	cd ${CAFFE_ON_SPARK}/caffe-grid/src/main/python/; zip -r caffeonsparkpythonapi  *; mv caffeonsparkpythonapi.zip ${CAFFE_ON_SPARK}/caffe-grid/target/;cd ${CAFFE_ON_SPARK}
 	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; export SPARK_HOME="${SPARK_HOME}"; ${CAFFE_ON_SPARK}/caffe-grid/src/test/python/PythonTest.sh
-buildosx: 
+buildosx:
 	cd caffe-public; make proto; make -j4 -e distribute; cd ..
-	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH2}"; mvn -B package -DskipTests
+	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH2}"; mvn ${MVN_SPARK_FLAG} -B package -DskipTests
 	jar -xvf caffe-grid/target/caffe-grid-0.1-SNAPSHOT-jar-with-dependencies.jar META-INF/native/osx64/liblmdbjni.jnilib
 	mv META-INF/native/osx64/liblmdbjni.jnilib ${CAFFE_ON_SPARK}/caffe-distri/distribute/lib
 	${CAFFE_ON_SPARK}/scripts/setup-mnist.sh
-	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH2}"; mvn -B package
+	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH2}"; mvn ${MVN_SPARK_FLAG} -B package
 	cp -r ${CAFFE_ON_SPARK}/caffe-public/python/caffe ${CAFFE_ON_SPARK}/caffe-grid/src/main/python/
 	cd ${CAFFE_ON_SPARK}/caffe-grid/src/main/python/; zip -r caffeonsparkpythonapi  *; mv caffeonsparkpythonapi.zip ${CAFFE_ON_SPARK}/caffe-grid/target/; cd ${CAFFE_ON_SPARK}
 	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH2}"; export SPARK_HOME="${SPARK_HOME}"; ${CAFFE_ON_SPARK}/caffe-grid/src/test/python/PythonTest.sh
@@ -39,9 +44,9 @@ gh-pages:
 	rm -rf scala_doc
 	git checkout gh-pages scala_doc
 
-clean: 
+clean:
 	cd caffe-public; make clean; cd ..
 	cd caffe-distri; make clean; cd ..
-	mvn clean 
+	mvn ${MVN_SPARK_FLAG} clean
 
 ALL: build

--- a/README.md
+++ b/README.md
@@ -60,30 +60,11 @@ cluster](../../wiki/GetStarted_EC2).
 
 ## Building for Spark 2.X
 
-Optional: To use a local **SNAPSHOT** version of Spark: first perform a  **mvn install** from your local Spark to your local maven repository as follows:
-
-<pre>
-   cd $SPARK_HOME
-   mvn <spark options\> install
-</pre>
-
-Next: configure the **CaffeOnSpark/caffe-grid** maven build to use the correct versions of Spark for your environment.
-
-You may either :
-
-1)  Accept the "default" Spark2.X settings by using
-
-     mvn -Dspark2 clean package
-
-The default settings are:
-
-  - spark-2.0.0-SNAPSHOT
+CaffeOnSpark supports both Spark 1.x and 2.x. For Spark 2.0, our default settings are:
+  - spark-2.0.0
   - hadoop-2.7.1
   - scala-2.11.7
-
-2) You can manually specify particular values yourself. For example for the 2.0.0-preview with hadoop 2.7.2 and scala 2.11.8:
-
-    mvn -Dspark.version=2.0.0-preview -Dhadoop.version=2.7.2 -Dscala.major.version=2.11 -Dscala.version=2.11.8 clean package
+You may want to adjust them in caffe-grid/pom.xml.
 
  
 ## Mailing List

--- a/caffe-grid/pom.xml
+++ b/caffe-grid/pom.xml
@@ -35,8 +35,7 @@
         <hadoop.version>2.7.1</hadoop.version>
         <scala.version>2.11.7</scala.version>
         <scala.major.version>2.11</scala.major.version>
-        <slf4j.version>1.6.6</slf4j.version>
-        <spark.version>2.0.0-SNAPSHOT</spark.version>
+        <spark.version>2.0.0</spark.version>
       </properties>
     </profile>
   </profiles>

--- a/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
+++ b/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
@@ -17,7 +17,11 @@ class CaffeOnSpark:
 
     def __init__(self,sc):
         registerContext(sc)
-        wrapClass("org.apache.spark.sql.Dataset")
+        spark_major_version = int(sc.version.split(' ')[0])
+        if spark_major_version == 2:
+            wrapClass("org.apache.spark.sql.Dataset")
+        else:
+            wrapClass("org.apache.spark.sql.DataFrame")
         self.__dict__['caffeonspark']=wrapClass("com.yahoo.ml.caffe.CaffeOnSpark")
         self.__dict__['cos']=self.__dict__.get('caffeonspark')(sc)
         self.__dict__['sqlcontext']=SQLContext(sc,self.__dict__['cos'].sqlContext)

--- a/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
+++ b/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
@@ -7,7 +7,6 @@ Please see LICENSE file in the project root for terms.
 from ConversionUtil import wrapClass
 from RegisterContext import registerContext
 from pyspark.sql import DataFrame,SQLContext
-from pyspark.mllib.linalg import Vectors
 
 class CaffeOnSpark:
     """CaffeOnSpark is the main class for distributed deep learning. 
@@ -18,7 +17,7 @@ class CaffeOnSpark:
 
     def __init__(self,sc):
         registerContext(sc)
-        wrapClass("org.apache.spark.sql.DataFrame")
+        wrapClass("org.apache.spark.sql.Dataset")
         self.__dict__['caffeonspark']=wrapClass("com.yahoo.ml.caffe.CaffeOnSpark")
         self.__dict__['cos']=self.__dict__.get('caffeonspark')(sc)
         self.__dict__['sqlcontext']=SQLContext(sc,self.__dict__['cos'].sqlContext)

--- a/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
+++ b/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
@@ -18,7 +18,7 @@ class CaffeOnSpark:
     def __init__(self,sc):
         registerContext(sc)
         spark_major_version = int(sc.version.split(' ')[0])
-        if spark_major_version == 2:
+        if spark_major_version >= 2:
             wrapClass("org.apache.spark.sql.Dataset")
         else:
             wrapClass("org.apache.spark.sql.DataFrame")

--- a/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
+++ b/caffe-grid/src/main/python/com/yahoo/ml/caffe/CaffeOnSpark.py
@@ -17,7 +17,7 @@ class CaffeOnSpark:
 
     def __init__(self,sc):
         registerContext(sc)
-        spark_major_version = int(sc.version.split(' ')[0])
+        spark_major_version = int(sc.version.split('.')[0])
         if spark_major_version >= 2:
             wrapClass("org.apache.spark.sql.Dataset")
         else:

--- a/caffe-grid/src/main/scala/com/yahoo/ml/caffe/DataFrameSource.scala
+++ b/caffe-grid/src/main/scala/com/yahoo/ml/caffe/DataFrameSource.scala
@@ -105,7 +105,7 @@ class DataFrameSource(conf: Config, layerId: Int, isTrain: Boolean)
     val has_id : Boolean = columnNames.contains("id")
 
     //mapping each row to RDD tuple
-    df.map(row => {
+    df.rdd.map(row => {
       val id: String = if (!has_id) "" else row.getAs[String]("id")
       val sample = new Array[Any](numTops)
       (0 until numTops).map(i => sample(i) = row.getAs[Any](topNames(i)))

--- a/caffe-grid/src/main/scala/com/yahoo/ml/caffe/DataFrameSource.scala
+++ b/caffe-grid/src/main/scala/com/yahoo/ml/caffe/DataFrameSource.scala
@@ -136,16 +136,16 @@ class DataFrameSource(conf: Config, layerId: Int, isTrain: Boolean)
     val imageWidth = tops(topidx).width_
     val imageChannels = tops(topidx).channels_
     if (encoded) {
-       mat = new Mat(data)
-       imageChannels match {
-          case 1 => mat.decode(Mat.CV_LOAD_IMAGE_GRAYSCALE)
-          case 3 => mat.decode(Mat.CV_LOAD_IMAGE_COLOR)
-          case _ => mat.decode(Mat.CV_LOAD_IMAGE_UNCHANGED)
-        }
+      mat = new Mat(data)
+      imageChannels match {
+        case 1 => mat.decode(Mat.CV_LOAD_IMAGE_GRAYSCALE)
+        case 3 => mat.decode(Mat.CV_LOAD_IMAGE_COLOR)
+        case _ => mat.decode(Mat.CV_LOAD_IMAGE_UNCHANGED)
+      }
 
       if (mat.width() == 0) {
-      	log.warn("Skip image at top#" + topidx + ", index#" + offset)
-    	mat = null
+        log.warn("Skip image at top#" + topidx + ", index#" + offset)
+        mat = null
       }
     } else {
       mat = new Mat(imageChannels, imageHeight, imageWidth, data)


### PR DESCRIPTION
This PR enables CaffeOnSpark to work with both Spark 1.x and Spark 2.x. 
Once you provide appropriate SPARK_HOME, Spark 1.x/2.x could be built via "make build".