### PR TITLE
Makefile and pom.xml changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ export SPARK_VERSION=$(shell ${SPARK_HOME}/bin/spark-submit --version 2>&1 | gre
 ifeq (${SPARK_VERSION}, 2)
     export MVN_SPARK_FLAG=-Dspark2
 endif
+ifeq (${object_storage}, 1)
+    export MVN_SPARK_FLAG=-Dspark2 -Dobject_storage
+endif
 
 build:
 	cd caffe-public; make proto; make -j4 -e distribute; cd ..

--- a/caffe-grid/pom.xml
+++ b/caffe-grid/pom.xml
@@ -38,6 +38,21 @@
         <spark.version>2.0.0</spark.version>
       </properties>
     </profile>
+    <profile>
+      <id>object_storage</id>
+      <activation>
+        <property>
+          <name>object_storage</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-openstack</artifactId>
+          <version>2.7.1</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Changes to reflect Makefile and pom.xml changes to include the `hadoop-openstack` dependency as a profile named `object_storage` so that we can build CaffeOnSpark using `make build object_storage=1`